### PR TITLE
Add option to mark entries billable

### DIFF
--- a/pi/main_pi.html
+++ b/pi/main_pi.html
@@ -55,7 +55,7 @@
       <div class="sdpi-item-label">Billable</div>
       <select class="sdpi-item-value select" id="billable" onchange="sendSettings()">
         <option value="0" selected>No</option>
-        <option value="1">Yes</option>
+        <option value="1">Yes (paid Toggl plans only)</option>
       </select>
     </div>
     <div class="sdpi-item">

--- a/pi/main_pi.html
+++ b/pi/main_pi.html
@@ -51,6 +51,13 @@
         <option value="0"></option>
       </select>
     </div>
+    <div class="sdpi-item invalidHidden hidden" id="billableWrapper">
+      <div class="sdpi-item-label">Billable</div>
+      <select class="sdpi-item-value select" id="billable" onchange="sendSettings()">
+        <option value="0" selected>No</option>
+        <option value="1">Yes</option>
+      </select>
+    </div>
     <div class="sdpi-item">
       <details class="message info">
         <summary class="sdpi-item-value">

--- a/pi/main_pi.js
+++ b/pi/main_pi.js
@@ -34,6 +34,7 @@ function connectElgatoStreamDeckSocket (inPort, inPropertyInspectorUUID, inRegis
       if (payload.apiToken) document.getElementById('apitoken').value = payload.apiToken
       if (payload.label) document.getElementById('label').value = payload.label
       if (payload.activity) document.getElementById('activity').value = payload.activity
+      document.getElementById('billable').value = payload.billableToggle ? 1 : 0
 
       const apiToken = document.getElementById('apitoken').value
 
@@ -61,7 +62,8 @@ function sendSettings () {
       label: document.getElementById('label').value,
       activity: document.getElementById('activity').value,
       workspaceId: document.getElementById('wid').value,
-      projectId: document.getElementById('pid').value
+      projectId: document.getElementById('pid').value,
+      billableToggle: document.getElementById('billable').value == 1 ?  true : false
     }
   }))
 }
@@ -85,6 +87,7 @@ async function updateProjects (apiToken, workspaceId) {
       document.getElementById('pid').innerHTML = '<option value="0"></option>'
       document.getElementById('workspaceError').classList.add('hiddenError')
       document.getElementById('projectWrapper').classList.remove('hidden')
+      document.getElementById('billableWrapper').classList.remove('hidden')
       const selectEl = document.getElementById('pid')
 
       for (projectNum in projectsData) {
@@ -96,6 +99,7 @@ async function updateProjects (apiToken, workspaceId) {
     })
   } catch (e) {
     document.getElementById('projectWrapper').classList.add('hidden')
+    document.getElementById('billableWrapper').classList.add('hidden')
     document.getElementById('workspaceError').classList.remove('hiddenError')
   }
 }

--- a/plugin/main.js
+++ b/plugin/main.js
@@ -121,25 +121,25 @@ function leadingZero(val)
 }
 
 async function toggle(context, settings) {
-  const { apiToken, activity, projectId, workspaceId } = settings
+  const { apiToken, activity, projectId, workspaceId, billableToggle } = settings
 
   getCurrentEntry(apiToken).then(entryData => {
     if (!entryData) {
       //Not running? Start a new one
-      startEntry(apiToken, activity, workspaceId, projectId).then(v=>refreshButtons())
+      startEntry(apiToken, activity, workspaceId, projectId, billableToggle).then(v=>refreshButtons())
     } else if (entryData.wid == workspaceId && entryData.pid == projectId && entryData.description == activity) {
       //The one running is "this one" -- toggle to stop
       stopEntry(apiToken, entryData.id).then(v=>refreshButtons())
     } else {
       //Just start the new one, old one will stop, it's toggl.
-      startEntry(apiToken, activity, workspaceId, projectId).then(v=>refreshButtons())
+      startEntry(apiToken, activity, workspaceId, projectId, billableToggle).then(v=>refreshButtons())
     }
   })
 }
 
 // Toggl API Helpers
 
-function startEntry(apiToken = isRequired(), activity = 'Time Entry created by Toggl for Stream Deck', workspaceId = 0, projectId = 0) {
+function startEntry(apiToken = isRequired(), activity = 'Time Entry created by Toggl for Stream Deck', workspaceId = 0, projectId = 0, billableToggle = false) {
   return fetch(
     `${togglBaseUrl}/time_entries/start`, {
     method: 'POST',
@@ -152,6 +152,7 @@ function startEntry(apiToken = isRequired(), activity = 'Time Entry created by T
         description: activity,
         wid: workspaceId,
         pid: projectId,
+	billable: billableToggle,
         created_with: 'Stream Deck'
       }
     })


### PR DESCRIPTION
I added an option to mark time entries billable on button push.

This requires a paid Toggl subscription. Whether trying to mark an entry billable on a free plan is an error that must be checked for in advance, or it's just a super narrow edge case, I can't tell right now. For the moment, there's just a text in the drop-down selector hinting towards this being a paid feature.