### PR TITLE
Add note to leave title blank (so timer works)

### DIFF
--- a/pi/main_pi.html
+++ b/pi/main_pi.html
@@ -16,6 +16,11 @@
 <body>
   <div class="sdpi-wrapper hiddenAll">
     <div class="sdpi-item">
+      <details class="message">
+        <summary style="margin-top: -10px">Leave Title blank to enable timer display. Use Button Label instead.</a></summary>
+      </details>
+    </div>
+    <div class="sdpi-item">
       <div class="sdpi-item-label">API Token</div>
       <input class="sdpi-item-value" id="apitoken" value="" pattern="[a-z0-9]+" placeholder="Enter your Private API Token"
         onchange="setAPIToken()" required>


### PR DESCRIPTION
If you leave the Title field empty and use Button Label instead, the time will be displayed. This seems to be an issue with the setTitle action in Strem Deck. This change adds a note directly below the title field (which is added by Stream Deck).

https://www.reddit.com/r/StreamDeckSDK/comments/axp0zp/how_to_update_title_field_in_property_inspector/

Fixes #14 