### PR TITLE
Refresh buttons when starting an entry to quickly update the previous button

### DIFF
--- a/plugin/main.js
+++ b/plugin/main.js
@@ -133,6 +133,8 @@ async function toggle(context, settings) {
     } else {
       //Just start the new one, old one will stop, it's toggl.
       startEntry(apiToken, activity, workspaceId, projectId, billableToggle).then(v=>refreshButtons())
+      // Let's not wait until the next polling to disable the old button
+      refreshButtons();
     }
   })
 }


### PR DESCRIPTION
This is a quick-fix for the issue where starting a new timer doesn't reset the already running button.

Currently the plugin leaves it for the next Polling to update, which could be up to 5 seconds (and is buggy at the moment).

This change simply triggers a refresh of all buttons after starting the new timer.

https://github.com/tobimori/streamdeck-toggl/issues/30