### PR TITLE
Allow for template string {{prompt}} in the entry name

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Just search for the Action "Toggl" within the Stream Deck app and install it. Th
 
 Just press any Toggl Button to start tracking time. The button should indicate tracking by turning red and showing the current tracking time (if no *Title* is set). The status of the button is defined by workspace, project and entry name. If you setup two identical buttons (even on different Stream Deck profiles), both button indicate the same. If you start or stop your timer using the Toggl app (web, desktop, mobile) Toggl for Stream Deck will follow by changing the status.
 
+## Variable Entry Names
+
+You can have dynamic bits of yoru Entry Name by using the template `{{prompt}}` (no spaces).
+
+A prompt will appear to ask what it should be replaced with. Due to a limitation of the Stream Deck, the prompt may appear behind other apps.
+
 ## 📞 Help
 
 Feel free to ask your questions on [my Discord Server](https://discord.gg/YWy3UAy). Please use GitHub Issues for reporting bugs and requesting new features.

--- a/plugin/main.js
+++ b/plugin/main.js
@@ -140,6 +140,10 @@ async function toggle(context, settings) {
 // Toggl API Helpers
 
 function startEntry(apiToken = isRequired(), activity = 'Time Entry created by Toggl for Stream Deck', workspaceId = 0, projectId = 0, billableToggle = false) {
+  if (activity.includes('{{prompt}}')) {
+    let promptVal = prompt('What entry name would you like?');
+    activity = activity.replace('{{prompt}}', promptVal);
+  }
   return fetch(
     `${togglBaseUrl}/time_entries/start`, {
     method: 'POST',


### PR DESCRIPTION
An imperfect fix for the issue below.

There's no way to get a prompt which has focus, but this might enable a workable workflow for somebody.

This may break when Chrome removed the native `prompt()` functions, which I think is due for later this year.

But for now at least, hopefully it's helpful!

https://github.com/tobimori/streamdeck-toggl/issues/23